### PR TITLE
waddy: `TopBottomPanel` for search bar

### DIFF
--- a/src/gui/programs/waddy.rs
+++ b/src/gui/programs/waddy.rs
@@ -622,24 +622,26 @@ impl WaddyGui {
 
         // search bar
         if self.instances[instance_index].search.enable {
-            let size = ui.ctx().used_size();
+            egui::TopBottomPanel::bottom(format!("search_bar{}", instance_index)).show(
+                ui.ctx(),
+                |ui| {
+                    ui.horizontal(|ui| {
+                        let text_edit = egui::TextEdit::singleline(
+                            &mut self.instances[instance_index].search.text,
+                        )
+                        .hint_text("Search for texture");
 
-            egui::Area::new(egui::Id::new(format!("search_bar{}", instance_index)))
-                .fixed_pos(egui::pos2(8., size.y))
-                .show(ui.ctx(), |ui| {
-                    let text_edit =
-                        egui::TextEdit::singleline(&mut self.instances[instance_index].search.text)
-                            .hint_text("Search for texture");
+                        let text_edit = ui.add(text_edit);
 
-                    let text_edit = ui.add(text_edit).highlight();
+                        if self.instances[instance_index].search.should_focus {
+                            text_edit.request_focus();
+                            self.instances[instance_index].search.should_focus = false;
+                        }
 
-                    if self.instances[instance_index].search.should_focus {
-                        text_edit.request_focus();
-                        self.instances[instance_index].search.should_focus = false;
-                    }
-
-                    self.instances[instance_index].search.has_focus = text_edit.has_focus();
-                });
+                        self.instances[instance_index].search.has_focus = text_edit.has_focus();
+                    });
+                },
+            );
         }
 
         // Save WAD file with Ctrl+S


### PR DESCRIPTION
The search bar is now fixed to the bottom panel without the weird animation movement

Before:

https://github.com/user-attachments/assets/35fee773-56fb-49e3-aa98-385ad4f28185



After:

https://github.com/user-attachments/assets/7d7f6224-9879-42d3-a98f-d19f6a006be2

